### PR TITLE
Address Android storage limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ persistCache({
   // 'background': Persist when your app moves to the background. React Native only.
   //
   // For a custom trigger, provide a function. See below for more information.
-  trigger?: 'write' | 'background' | function,
+  // To disable automatic persistence and manage persistence manually, provide false.
+  trigger?: 'write' | 'background' | function | false,
 
   // Debounce interval between persists (in ms).
   // Defaults to 0 for 'background' and 1000 for 'write' and custom triggers.
@@ -98,9 +99,10 @@ persistCache({
   // Whether to serialize to JSON before/after persisting. Defaults to true.
   serialize?: boolean,
 
-  // Maximum size of cache to persist (in bytes). Defaults to undefined.
+  // Maximum size of cache to persist (in bytes).
+  // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
   // If exceeded, persistence will pause and app will start up cold on next launch.
-  maxSize?: number,
+  maxSize?: number | false,
 
   /**
    * Debugging options.
@@ -188,6 +190,13 @@ including:
 * [`redux-persist-node-storage`](https://github.com/pellejacobs/redux-persist-node-storage)
 * [`redux-persist-fs-storage`](https://github.com/leethree/redux-persist-fs-storage)
 * [`redux-persist-cookie-storage`](https://github.com/abersager/redux-persist-cookie-storage)
+
+If you're using React Native and set a `maxSize` in excess of 2 MB, you must use
+a filesystem-based storage provider, such as
+[`redux-persist-fs-storage`](https://github.com/leethree/redux-persist-fs-storage).
+`AsyncStorage`
+[does not support](https://github.com/facebook/react-native/issues/12529#issuecomment-345326643)
+individual values in exceed of 2 MB on Android.
 
 ## Common Questions
 
@@ -281,3 +290,15 @@ async function setupApollo() {
   // Continue setting up Apollo as usual.
 }
 ```
+
+#### I'm seeing errors on Android.
+
+Specifically, this error:
+
+```
+BaseError: Couldn't read row 0, col 0 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
+```
+
+This is the result of a 2 MB limitation of `AsyncStorage` on Android. Set a
+smaller `maxSize` or switch to a filesystem-based storage provider, such as
+[`redux-persist-fs-storage`](https://github.com/leethree/redux-persist-fs-storage).

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -30,12 +30,12 @@ export default class Trigger<T> {
       return;
     }
 
+    this.debounce = debounce != null ? debounce : defaultDebounce;
     this.persistor = persistor;
     this.paused = false;
 
     switch (trigger) {
       case 'write':
-        this.debounce = debounce || defaultDebounce;
         this.uninstall = onCacheWrite({ cache })(this.fire);
         break;
 

--- a/src/__tests__/__snapshots__/persistCache.ts.snap
+++ b/src/__tests__/__snapshots__/persistCache.ts.snap
@@ -6,8 +6,6 @@ exports[`persistCache advanced usage passing in key customizes the storage key 1
 
 exports[`persistCache advanced usage setting maxSize purges the Apollo cache & storage if it crosses a threshold 1`] = `undefined`;
 
-exports[`persistCache advanced usage setting maxSize purges the Apollo cache & storage if it crosses a threshold 2`] = `Object {}`;
-
 exports[`persistCache setup requires a cache 1`] = `"In order to persist your Apollo Cache, you need to pass in a cache. Please see https://www.apollographql.com/docs/react/basics/caching.html for our default InMemoryCache."`;
 
 exports[`persistCache setup requires storage 1`] = `"In order to persist your Apollo Cache, you need to pass in an underlying storage provider. Please see https://github.com/apollographql/apollo-cache-persist#storage-providers"`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,10 +19,10 @@ export interface PersistentStorage<T> {
 export interface ApolloPersistOptions<TSerialized> {
   cache: ApolloCache<TSerialized>;
   storage: PersistentStorage<PersistedData<TSerialized>>;
-  trigger?: 'write' | 'background' | TriggerFunction;
+  trigger?: 'write' | 'background' | TriggerFunction | false;
   debounce?: number;
   key?: string;
   serialize?: boolean;
+  maxSize?: number | false;
   debug?: boolean;
-  maxSize?: number;
 }


### PR DESCRIPTION
Also touched a couple other features.

* Added a `false` option for `trigger`, which prevents no triggers from being used.
* Set a default of 1MB for `maxSize` and added a `false` option for disabling `maxSize`.
* Ensured default `debounce` applies to custom triggers.
* Added multiple notes about Android size limits (and recommendations to use fs-based storage).