### PR TITLE
Fix #17: Modify storage types to accept synchronous results

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -15,16 +15,16 @@ export default class Storage<T> {
     this.key = key;
   }
 
-  read(): Promise<PersistedData<T>> {
+  async read(): Promise<PersistedData<T>> {
     return this.storage.getItem(this.key);
   }
 
-  write(data: PersistedData<T>): Promise<void> {
-    return this.storage.setItem(this.key, data);
+  async write(data: PersistedData<T>): Promise<void> {
+    await this.storage.setItem(this.key, data);
   }
 
-  purge(): Promise<void> {
-    return this.storage.removeItem(this.key);
+  async purge(): Promise<void> {
+    await this.storage.removeItem(this.key);
   }
 
   async getSize(): Promise<number | null> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,12 +8,12 @@ export type TriggerUninstallFunction = () => void;
 
 export type TriggerFunction = (persist: () => void) => TriggerUninstallFunction;
 
-export type PersistedData<T> = T | string;
+export type PersistedData<T> = T | string | null;
 
 export interface PersistentStorage<T> {
-  getItem: (key: string) => Promise<T>;
-  setItem: (key: string, data: T) => Promise<void>;
-  removeItem: (key: string) => Promise<void>;
+  getItem: (key: string) => Promise<T> | T;
+  setItem: (key: string, data: T) => Promise<void> | void;
+  removeItem: (key: string) => Promise<void> | void;
 }
 
 export interface ApolloPersistOptions<TSerialized> {


### PR DESCRIPTION
`localStorage` is synchronous, so we don't always receive a promise from the storage provider. This PR massages the types to support this common scenario.

The `awaits` have been added to the `Storage` module in order to guarantee is returned from those methods regardless of whether the underlying storage provider returns a function. This is a convenience to prevent the proliferation of `Promise<T> | T` union types.