### PR TITLE
Whitelist and Blacklist like redux-persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/apollographql/apollo-cache-persist#readme",
   "bugs": "https://github.com/apollographql/apollo-cache-persist/issues",
   "scripts": {
+    "prepare": "npm run build",
     "build:browser":
       "browserify ./lib/bundle.umd.js -o=./lib/bundle.js && npm run minify:browser",
     "build": "tsc -p .",

--- a/src/Persistor.ts
+++ b/src/Persistor.ts
@@ -16,26 +16,79 @@ export default class Persistor<T> {
   storage: Storage<T>;
   maxSize?: number;
   paused: boolean;
+  whitelist?: Array<string>;
+  blacklist?: Array<string>;
 
   constructor(
     { log, cache, storage }: PersistorConfig<T>,
     options: ApolloPersistOptions<T>
   ) {
-    const { maxSize = 1024 * 1024 } = options;
+    const { maxSize = 1024 * 1024, whitelist, blacklist } = options;
 
     this.log = log;
     this.cache = cache;
     this.storage = storage;
     this.paused = false;
+    this.whitelist = whitelist;
+    this.blacklist = blacklist;
+
+    if (whitelist && blacklist) {
+      this.log.error('Not necessary to set both whitelist and blacklist.');
+    }
 
     if (maxSize) {
       this.maxSize = maxSize;
     }
   }
 
+  filterMap(
+    map: { [key: string]: any },
+    filterFn: (key: string) => boolean
+  ): { [key: string]: any } {
+    return Object.keys(map)
+      .filter(filterFn)
+      .reduce((obj: { [key: string]: any }, key: string) => {
+        obj[key] = map[key];
+        return obj;
+      }, {});
+  }
+
+  searchList(list: Array<string>, key: string, prefix: string = null): boolean {
+    const keyArr = key.split(/[\.\(]/);
+    for (let item of list) {
+      if (
+        (!prefix && keyArr[0] === item) ||
+        (prefix && keyArr[0].includes(prefix) && keyArr[1] === item)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   async persist(): Promise<void> {
     try {
-      const data = this.cache.extract();
+      const cacheData = this.cache.cache.extract() as { [key: string]: any };
+      // first layer cache
+      const filteredData = this.filterMap(cacheData, (key: string) => {
+        if (key === 'ROOT_QUERY') return true;
+        if (this.whitelist)
+          return this.searchList(this.whitelist, key, 'ROOT_QUERY');
+        if (this.blacklist)
+          return !this.searchList(this.blacklist, key, 'ROOT_QUERY');
+        return true;
+      });
+      // second layer cache under ROOT_QUERY
+      filteredData['ROOT_QUERY'] = this.filterMap(
+        filteredData['ROOT_QUERY'],
+        (key: string) => {
+          if (this.whitelist) return this.searchList(this.whitelist, key);
+          if (this.blacklist) return !this.searchList(this.blacklist, key);
+          return true;
+        }
+      );
+
+      const data = JSON.stringify(filteredData);
 
       if (
         this.maxSize != null &&
@@ -54,6 +107,7 @@ export default class Persistor<T> {
 
       await this.storage.write(data);
 
+      this.log.info('Persisted cache', filteredData);
       this.log.info(
         typeof data === 'string'
           ? `Persisted cache of size ${data.length}`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,5 +24,7 @@ export interface ApolloPersistOptions<TSerialized> {
   key?: string;
   serialize?: boolean;
   maxSize?: number | false;
+  whitelist?: Array<string>;
+  blacklist?: Array<string>;
   debug?: boolean;
 }


### PR DESCRIPTION
- [x] feature

Add whitelist and blacklist functions like `redux-persist` for persisting specific query cache properly.
Currently support `Query`. And add filters of `Subscription` and `Mutation` later.

This is the structure of cache
```
$ROOT_QUERY.auth: { __typename: "Auth", ... }
$ROOT_QUERY.me: { __typename: "Profile", ... }
$ROOT_QUERY.preference: { __typename: "Preference", ... }
ROOT_QUERY: { auth: { ... }, preference: { ... }, me: { ... }, ... }
```

The cache structure contains at least two layers, the first layer starts with `$ROOT_QUERY` or `ROOT_QUERY` and the second layer is under `ROOT_QUERY`.
Both layers must be filtered.

And add `"prepare": "npm run build"` in package.json for installing lib from GitHub