### PR TITLE
Fix writes while Persistor is paused

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/jest": "^24.0.18",
     "@types/node": "12.7.5",
     "@types/react-native": "0.60.13",
     "apollo-cache": "1.3.2",

--- a/src/Persistor.ts
+++ b/src/Persistor.ts
@@ -19,7 +19,7 @@ export default class Persistor<T> {
 
   constructor(
     { log, cache, storage }: PersistorConfig<T>,
-    options: ApolloPersistOptions<T>
+    options: ApolloPersistOptions<T>,
   ) {
     const { maxSize = 1024 * 1024 } = options;
 
@@ -49,7 +49,7 @@ export default class Persistor<T> {
       }
 
       if (this.paused) {
-        this.paused = false;
+        return;
       }
 
       await this.storage.write(data);
@@ -57,7 +57,7 @@ export default class Persistor<T> {
       this.log.info(
         typeof data === 'string'
           ? `Persisted cache of size ${data.length} characters`
-          : 'Persisted cache'
+          : 'Persisted cache',
       );
     } catch (error) {
       this.log.error('Error persisting cache', error);
@@ -75,7 +75,7 @@ export default class Persistor<T> {
         this.log.info(
           typeof data === 'string'
             ? `Restored cache of size ${data.length} characters`
-            : 'Restored cache'
+            : 'Restored cache',
         );
       } else {
         this.log.info('No stored cache to restore');

--- a/src/__mocks__/MockCache.ts
+++ b/src/__mocks__/MockCache.ts
@@ -1,0 +1,33 @@
+import Cache from '../Cache';
+import { ApolloPersistOptions, PersistedData } from '../types';
+
+export default class MockCache<T> implements Cache<T> {
+  cache: null;
+  serialize: boolean;
+  data: PersistedData<T>;
+
+  constructor(options: ApolloPersistOptions<T>) {
+    const { serialize = true } = options;
+    this.serialize = serialize;
+  }
+
+  extract(): PersistedData<T> {
+    let data: PersistedData<T> = this.data;
+
+    if (this.serialize) {
+      data = JSON.stringify(this.data) as string;
+    }
+
+    return data;
+  }
+
+  restore(data: PersistedData<T>): void {
+    if (this.serialize && typeof data === 'string') {
+      data = JSON.parse(data);
+    }
+
+    if (data != null) {
+      this.data = data;
+    }
+  }
+}

--- a/src/__tests__/Persistor.ts
+++ b/src/__tests__/Persistor.ts
@@ -1,0 +1,31 @@
+import MockStorage from '../__mocks__/MockStorage';
+import MockCache from '../__mocks__/MockCache';
+import Persistor from '../Persistor';
+import Storage from '../Storage';
+import Log from '../Log';
+
+describe('Persistor', () => {
+  const cache = new MockCache({ serialize: false });
+  const storage = new Storage({ storage: new MockStorage() });
+  jest.spyOn(storage, 'write');
+  const persistor = new Persistor(
+    {
+      log: new Log({ debug: false }),
+      storage,
+      cache,
+    },
+    { maxSize: 100 },
+  );
+
+  it('should not write more than maxSize', async () => {
+    cache.restore('0'.repeat(101));
+    await persistor.persist();
+    expect(storage.write).not.toHaveBeenCalled();
+  });
+
+  it('should not commit writes after pause', async () => {
+    cache.restore('0'.repeat(101));
+    persistor.persist();
+    expect(storage.write).not.toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,6 +76,18 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
 
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.18":
+  version "24.0.18"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.18.tgz#9c7858d450c59e2164a8a9df0905fc5091944498"
+  integrity sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==
+  dependencies:
+    "@types/jest-diff" "*"
+
 "@types/node@12.7.5":
   version "12.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,18 +76,6 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
 
-"@types/jest-diff@*":
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
-  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
-
-"@types/jest@^24.0.18":
-  version "24.0.18"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.18.tgz#9c7858d450c59e2164a8a9df0905fc5091944498"
-  integrity sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==
-  dependencies:
-    "@types/jest-diff" "*"
-
 "@types/node@12.7.5":
   version "12.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"


### PR DESCRIPTION
The first call to persist with cache size > `maxSize` fails and leads to a `purge` and sets `paused` to true, but then consecutive calls to persist caused `paused` to be set to true again and the write going through. Leading eventually to quota exceeded errors and the likes.

This PR aims to solve that by preserving `paused` state to the end of the persistor's lifetime, as explained by the following lines in the README:
```
  // Maximum size of cache to persist (in bytes).
  // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
  // If exceeded, persistence will pause and app will start up cold on next launch.
```