### PR TITLE
Updated README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ class App extends Component {
 
 ```js
 import React,{ useState, useEffect } from 'react';
-import ApolloClient, { InMemoryCache } from "apollo-boost";
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloProvider } from "@apollo/react-hooks"
 import { persistCache } from 'apollo-cache-persist';
 


### PR DESCRIPTION
changed those two packages(InMemoryCache and ApolloClient) source library because of the fact that apollo-boost is no longer recommended.
related mention: https://github.com/apollographql/apollo-cache-persist/pull/318#discussion_r341846212