### PR TITLE
types: PersistentStorage.getItem Promise<T | null>

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export type TriggerFunction = (persist: () => void) => TriggerUninstallFunction;
 export type PersistedData<T> = T | string | null;
 
 export interface PersistentStorage<T> {
-  getItem: (key: string) => Promise<T> | T | null;
+  getItem: (key: string) => Promise<T | null> | T | null;
   setItem: (key: string, data: T) => Promise<T> | Promise<void> | void | T;
   removeItem: (key: string) => Promise<T> | Promise<void> | void;
 }


### PR DESCRIPTION
if the persistent storage is async in nature, we cannot ensure that it will return the value instead of null.

In sync behaviour we allow to return `T` or `null`, but in async we assume that it will return a promise of `T`.

We should return `Promise<T | null>` instead.