### PR TITLE
fix: export `PersistentStorage` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as CachePersistor } from './CachePersistor';
 export { default as persistCache } from './persistCache';
 export * from './persistCacheSync';
+export { PersistentStorage } from './types';


### PR DESCRIPTION
We currently do `import type { PersistentStorage } from 'apollo-cache-persist/types';` so that we can do `const storage: PersistentStorage<any> = {}` and get proper type completion. Exporting it seems cleaner 🙂 