### PR TITLE
Add trigger for cache.evict and cache.modify

### DIFF
--- a/src/onCacheWrite.ts
+++ b/src/onCacheWrite.ts
@@ -8,13 +8,28 @@ export default <T>({ cache }: TriggerFunctionConfig<T>) => (
   persist: () => void,
 ) => {
   const write = cache.write;
+  const evict = cache.evict;
+  const modify = cache.modify;
+
   cache.write = (...args: any[]) => {
-    const ref = write.apply(cache, args);
+    const result = write.apply(cache, args);
     persist();
-    return ref;
+    return result;
+  };
+  cache.evict = (...args: any[]) => {
+    const result = evict.apply(cache, args);
+    persist();
+    return result;
+  };
+  cache.modify = (...args: any[]) => {
+    const result = modify.apply(cache, args);
+    persist();
+    return result;
   };
 
   return () => {
     cache.write = write;
+    cache.evict = evict;
+    cache.modify = modify;
   };
 };


### PR DESCRIPTION
These changes were introduced in apollo-client 3.
The cache.modify and cache.evict function generated cache updates weren't persisted.