### PR TITLE
Add CommonJs Support (SyntaxError: Unexpected token 'export')

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Peggy Rayzis <peggy@meteor.com>"
   ],
   "license": "MIT",
-  "main": "./lib/index.js",
+  "main": "./lib/cjs/index.js",
   "module": "./lib/index.js",
   "jsnext:main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/apollographql/apollo-cache-persist/issues",
   "scripts": {
     "build:browser": "browserify ./lib/bundle.umd.js -o=./lib/bundle.js && npm run minify:browser",
-    "build": "tsc -p .",
+    "build": "tsc -p . && tsc -p ./tsconfig.cjs.json",
     "bundle": "rollup -c",
     "clean": "rimraf lib/* && rimraf coverage/*",
     "coverage:upload": "codecov",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib/cjs",
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
The `apollo3-cache-persist` module exported to npm is not CommonJS compatible at present, resulting in a `SyntaxError: Unexpected token 'export'` for me in Next.js.

The `tsconfig.json` file has `module` set to `es2015`, and this is presumably since Rollup (used to create a UMD module for the non-npm browser case) needs ES6 modules for tree-shaking to work. This change creates a fall-back CommonJS export (within `lib/cjs`) for any tooling that does not support the `module` key (also aliased as `jsnext:main`) in `package.json`.