### PR TITLE
Fix Storage API types

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ persistCache({
   cache: ApolloCache<TSerialized>,
 
   // Reference to your storage provider.
-  storage: PersistentStorage<TPersisted>,
+  storage: PersistentStorage,
 
   /**
    * Trigger options.

--- a/examples/web/src/index.tsx
+++ b/examples/web/src/index.tsx
@@ -9,7 +9,7 @@ import { PersistentStorage } from "apollo3-cache-persist/types";
 
 let persistor;
 
-class LocalStoragePersistedStorage implements PersistentStorage<string> {
+class LocalStoragePersistedStorage implements PersistentStorage {
   getItem(key: string): string | null {
     return localStorage.getItem(key);
   }

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -5,7 +5,7 @@ import {
 } from './types';
 
 export default class Storage<T> {
-  storage: PersistentStorage<PersistedData<T>>;
+  storage: PersistentStorage;
   key: string;
 
   constructor(options: ApolloPersistOptions<T>) {
@@ -20,7 +20,7 @@ export default class Storage<T> {
   }
 
   async write(data: PersistedData<T>): Promise<void> {
-    await this.storage.setItem(this.key, data);
+    await this.storage.setItem(this.key, data.toString());
   }
 
   async purge(): Promise<void> {

--- a/src/__mocks__/MockStorage.ts
+++ b/src/__mocks__/MockStorage.ts
@@ -1,13 +1,13 @@
 import { PersistentStorage } from '../types';
 
-export default class MockStorage<T> implements PersistentStorage<T> {
+export default class MockStorage implements PersistentStorage {
   storage: Map<string, string>;
 
   constructor() {
     this.storage = new Map();
   }
 
-  setItem(key: string, data: T): Promise<any> {
+  setItem(key: string, data: string): Promise<any> {
     return new Promise(resolve => {
       this.storage.set(key, data);
       resolve();
@@ -21,7 +21,7 @@ export default class MockStorage<T> implements PersistentStorage<T> {
     });
   }
 
-  getItem(key: string): Promise<T> {
+  getItem(key: string): Promise<string> {
     return new Promise((resolve, reject) => {
       resolve(this.storage.get(key));
     });

--- a/src/__mocks__/MockStorageSync.ts
+++ b/src/__mocks__/MockStorageSync.ts
@@ -1,13 +1,13 @@
 import { PersistentStorage } from '../types';
 
-export default class MockStorageSync<T> implements PersistentStorage<T> {
+export default class MockStorageSync implements PersistentStorage {
   storage: Map<string, string>;
 
   constructor() {
     this.storage = new Map();
   }
 
-  setItem(key: string, data): void {
+  setItem(key: string, data: string): void {
     this.storage.set(key, data);
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,15 +10,15 @@ export type TriggerFunction = (persist: () => void) => TriggerUninstallFunction;
 
 export type PersistedData<T> = T | string | null;
 
-export interface PersistentStorage<T> {
-  getItem: (key: string) => Promise<T | null> | T | null;
-  setItem: (key: string, data: T) => Promise<T> | Promise<void> | void | T;
-  removeItem: (key: string) => Promise<T> | Promise<void> | void;
+export interface PersistentStorage {
+  getItem: (key: string) => string | null | Promise<string | null>;
+  setItem: (key: string, value: string) => void | Promise<void>;
+  removeItem: (key: string) => void | Promise<void>;
 }
 
 export interface ApolloPersistOptions<TSerialized> {
   cache: ApolloCache<TSerialized>;
-  storage: PersistentStorage<PersistedData<TSerialized>>;
+  storage: PersistentStorage;
   trigger?: 'write' | 'background' | TriggerFunction | false;
   debounce?: number;
   key?: string;


### PR DESCRIPTION
Alignment of `PersistentStorage` with Typescript's internal types for the [`Storage` interface](https://developer.mozilla.org/en-US/docs/Web/API/Storage) of the Web Storage API (potential fix for #55).

This change removes the generic type `T` from `PersistentStorage`, which seemed unnecessary and unused. Apart from some type changes there's a single code change within `src/Storage.ts` which will want some scrutiny from those who understand the code better.