### PR TITLE
Introduce wrappers for individual storage providers

### DIFF
--- a/examples/react-native/App.tsx
+++ b/examples/react-native/App.tsx
@@ -11,7 +11,7 @@
 import React, { useEffect, useState } from 'react';
 import { SafeAreaView, StyleSheet, ScrollView, Text } from 'react-native';
 import { ApolloClient, InMemoryCache } from '@apollo/client';
-import { persistCache } from 'apollo3-cache-persist';
+import { persistCache, AsyncStorageWrapper } from 'apollo3-cache-persist';
 import AsyncStorage from '@react-native-community/async-storage';
 import { gql } from '@apollo/client';
 
@@ -26,7 +26,7 @@ const App = () => {
       const cache = new InMemoryCache();
       await persistCache({
         cache,
-        storage: AsyncStorage,
+        storage: new AsyncStorageWrapper(AsyncStorage),
       });
       const client = new ApolloClient({
         uri: 'https://48p1r2roz4.sse.codesandbox.io',

--- a/examples/web/src/index.tsx
+++ b/examples/web/src/index.tsx
@@ -4,29 +4,14 @@ import { render } from 'react-dom';
 import { ApolloProvider, ApolloClient, useQuery, makeVar, useReactiveVar } from '@apollo/client';
 import gql from 'graphql-tag';
 import { InMemoryCache } from '@apollo/client/core';
-import { CachePersistor } from 'apollo3-cache-persist';
-import { PersistentStorage } from "apollo3-cache-persist/types";
+import { CachePersistor, LocalStorageWrapper } from 'apollo3-cache-persist';
 
 let persistor;
-
-class LocalStoragePersistedStorage implements PersistentStorage {
-  getItem(key: string): string | null {
-    return localStorage.getItem(key);
-  }
-
-  removeItem(key: string) {
-    localStorage.removeItem(key);
-  }
-
-  setItem(key: string, data: any) {
-    localStorage.setItem(key, data);
-  }
-}
 
 async function createClient() {
   const cache = new InMemoryCache({});
   persistor = new CachePersistor({
-    storage: new LocalStoragePersistedStorage(),
+    storage: new LocalStorageWrapper(window.localStorage),
     cache,
   });
   await persistor.restore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { default as CachePersistor } from './CachePersistor';
 export { default as persistCache } from './persistCache';
 export * from './persistCacheSync';
-export * from './storageWrappers';
+export * from './storageWrappers/index';
 export { PersistentStorage } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as CachePersistor } from './CachePersistor';
 export { default as persistCache } from './persistCache';
 export * from './persistCacheSync';
+export * from './storageWrappers';
 export { PersistentStorage } from './types';

--- a/src/storageWrappers/AsyncStorageWrapper.ts
+++ b/src/storageWrappers/AsyncStorageWrapper.ts
@@ -1,0 +1,34 @@
+import { PersistentStorage } from '../types';
+
+/**
+ * Wrapper for react-native's AsyncStorage.
+ *
+ * WARNING: AsyncStorage doesn't support values in excess of 2MB on Android.
+ *
+ * @example
+ * const persistor = new CachePersistor({
+ *   cache,
+ *   storage: new AsyncStorageWrapper(AsyncStorage),
+ * });
+ *
+ */
+export default class AsyncStorageWrapper implements PersistentStorage {
+  // Actual type definition: https://github.com/react-native-async-storage/async-storage/blob/master/types/index.d.ts
+  private storage;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): string | Promise<string | null> | null {
+    return this.storage.getItem(key);
+  }
+
+  removeItem(key: string): void | Promise<void> {
+    return this.storage.removeItem(key);
+  }
+
+  setItem(key: string, value: string): void | Promise<void> {
+    return this.storage.setItem(key, value);
+  }
+}

--- a/src/storageWrappers/IonicStorageWrapper.ts
+++ b/src/storageWrappers/IonicStorageWrapper.ts
@@ -1,0 +1,22 @@
+import { PersistentStorage } from '../types';
+
+export default class IonicStorageWrapper implements PersistentStorage {
+  // Actual type definition: https://github.com/ionic-team/ionic-storage/blob/main/src/storage.ts#L102
+  private storage;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): string | Promise<string | null> | null {
+    return this.storage.get(key);
+  }
+
+  removeItem(key: string): void | Promise<void> {
+    return this.storage.remove(key);
+  }
+
+  setItem(key: string, value: string): void | Promise<void> {
+    return this.storage.set(key, value);
+  }
+}

--- a/src/storageWrappers/LocalForageWrapper.ts
+++ b/src/storageWrappers/LocalForageWrapper.ts
@@ -1,0 +1,27 @@
+import { PersistentStorage } from '../types';
+
+export default class LocalForageWrapper implements PersistentStorage {
+  // Actual type definition: https://github.com/localForage/localForage/blob/master/typings/localforage.d.ts#L17
+  private storage;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): string | Promise<string | null> | null {
+    return this.storage.getItem(key);
+  }
+
+  removeItem(key: string): void | Promise<void> {
+    return this.storage.removeItem(key);
+  }
+
+  setItem(key: string, value: string): void | Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.storage
+        .setItem(key, value)
+        .then(() => resolve())
+        .catch(() => reject());
+    });
+  }
+}

--- a/src/storageWrappers/LocalStorageWrapper.ts
+++ b/src/storageWrappers/LocalStorageWrapper.ts
@@ -1,0 +1,22 @@
+import { PersistentStorage } from '../types';
+
+export default class LocalStorageWrapper implements PersistentStorage {
+  // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
+  private storage;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): string | Promise<string | null> | null {
+    return this.storage.getItem(key);
+  }
+
+  removeItem(key: string): void | Promise<void> {
+    return this.storage.removeItem(key);
+  }
+
+  setItem(key: string, value: string): void | Promise<void> {
+    return this.storage.setItem(key, value);
+  }
+}

--- a/src/storageWrappers/MMKVStorageWrapper.ts
+++ b/src/storageWrappers/MMKVStorageWrapper.ts
@@ -1,0 +1,43 @@
+import { PersistentStorage } from '../types';
+
+/**
+ * Wrapper for react-native-mmkv-storage.
+ * See [https://rnmmkv.now.sh/#/gettingstarted](https://rnmmkv.now.sh/#/gettingstarted) for installation instructions.
+ *
+ * @example
+ * const persistor = new CachePersistor({
+ *   cache,
+ *   storage: new MMKVStorageWrapper(new MMKVStorage.Loader().initialize()),
+ * });
+ *
+ */
+export default class MMKVStorageWrapper implements PersistentStorage {
+  // Actual type definition: https://github.com/ammarahm-ed/react-native-mmkv-storage/blob/master/index.d.ts#L27
+  private storage;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): string | Promise<string | null> | null {
+    return this.storage.getItem(key);
+  }
+
+  removeItem(key: string): void | Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.storage
+        .removeItem(key)
+        .then(() => resolve())
+        .catch(() => reject());
+    });
+  }
+
+  setItem(key: string, value: string): void | Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.storage
+        .setItem(key, value)
+        .then(() => resolve())
+        .catch(() => reject());
+    });
+  }
+}

--- a/src/storageWrappers/SessionStorageWrapper.ts
+++ b/src/storageWrappers/SessionStorageWrapper.ts
@@ -1,0 +1,22 @@
+import { PersistentStorage } from '../types';
+
+export default class SessionStorageWrapper implements PersistentStorage {
+  // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
+  private storage;
+
+  constructor(storage: any) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): string | Promise<string | null> | null {
+    return this.storage.getItem(key);
+  }
+
+  removeItem(key: string): void | Promise<void> {
+    return this.storage.removeItem(key);
+  }
+
+  setItem(key: string, value: string): void | Promise<void> {
+    return this.storage.setItem(key, value);
+  }
+}

--- a/src/storageWrappers/index.ts
+++ b/src/storageWrappers/index.ts
@@ -1,0 +1,6 @@
+export * from './AsyncStorageWrapper';
+export * from './IonicStorageWrapper';
+export * from './LocalForageWrapper';
+export * from './LocalStorageWrapper';
+export * from './MMKVStorageWrapper';
+export * from './SessionStorageWrapper';


### PR DESCRIPTION
Hi,

this PR is my attempt to tackle the storage api consistency that's reappearing every now and then (last mentioned [here](https://github.com/apollographql/apollo-cache-persist/issues/325#issuecomment-708165178)).

This is a work in progress, just to get things moving and have some real code to start the discussion.

My approach here was to introduce wrappers that implement existing `PersistentStorage` interface (so we don't introduce BC break). Mostly the wrappers just proxy the call directly to the storage.

I've already found that IonicStorage joined the "no-item-movement" by renaming `getItem` to `get`, so the wrapper already fixes that.

Also LocalForage `setItem` signature was not compatible with `PersistentStorage`, so there's a tiny change to fix that.

I have no experience with publishing npm packages, so I'd appreciate any constructive criticism. For example, should the ionic/storage and localforage packages be installed as peerDependencies or devDependencies?

Thanks!