### PR TITLE
use named exports for storage wrappers

### DIFF
--- a/src/storageWrappers/AsyncStorageWrapper.ts
+++ b/src/storageWrappers/AsyncStorageWrapper.ts
@@ -12,7 +12,7 @@ import { PersistentStorage } from '../types';
  * });
  *
  */
-export default class AsyncStorageWrapper implements PersistentStorage {
+export class AsyncStorageWrapper implements PersistentStorage {
   // Actual type definition: https://github.com/react-native-async-storage/async-storage/blob/master/types/index.d.ts
   private storage;
 

--- a/src/storageWrappers/IonicStorageWrapper.ts
+++ b/src/storageWrappers/IonicStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export default class IonicStorageWrapper implements PersistentStorage {
+export class IonicStorageWrapper implements PersistentStorage {
   // Actual type definition: https://github.com/ionic-team/ionic-storage/blob/main/src/storage.ts#L102
   private storage;
 

--- a/src/storageWrappers/LocalForageWrapper.ts
+++ b/src/storageWrappers/LocalForageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export default class LocalForageWrapper implements PersistentStorage {
+export class LocalForageWrapper implements PersistentStorage {
   // Actual type definition: https://github.com/localForage/localForage/blob/master/typings/localforage.d.ts#L17
   private storage;
 

--- a/src/storageWrappers/LocalStorageWrapper.ts
+++ b/src/storageWrappers/LocalStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export default class LocalStorageWrapper implements PersistentStorage {
+export class LocalStorageWrapper implements PersistentStorage {
   // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
   private storage;
 

--- a/src/storageWrappers/MMKVStorageWrapper.ts
+++ b/src/storageWrappers/MMKVStorageWrapper.ts
@@ -11,7 +11,7 @@ import { PersistentStorage } from '../types';
  * });
  *
  */
-export default class MMKVStorageWrapper implements PersistentStorage {
+export class MMKVStorageWrapper implements PersistentStorage {
   // Actual type definition: https://github.com/ammarahm-ed/react-native-mmkv-storage/blob/master/index.d.ts#L27
   private storage;
 

--- a/src/storageWrappers/SessionStorageWrapper.ts
+++ b/src/storageWrappers/SessionStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export default class SessionStorageWrapper implements PersistentStorage {
+export class SessionStorageWrapper implements PersistentStorage {
   // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
   private storage;
 


### PR DESCRIPTION
There's an issue with exports of storage wrappers (#404).

First I thought it was just unreleased version, but there actually was an error in exports (default vs named) 🤦‍♂️