### PR TITLE
Allow unserialised data to be written to store

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -5,7 +5,7 @@ import {
 } from './types';
 
 export default class Storage<T> {
-  storage: PersistentStorage;
+  storage: PersistentStorage<PersistedData<T>>;
   key: string;
 
   constructor(options: ApolloPersistOptions<T>) {
@@ -20,7 +20,7 @@ export default class Storage<T> {
   }
 
   async write(data: PersistedData<T>): Promise<void> {
-    await this.storage.setItem(this.key, data.toString());
+    await this.storage.setItem(this.key, data);
   }
 
   async purge(): Promise<void> {

--- a/src/__tests__/Storage.ts
+++ b/src/__tests__/Storage.ts
@@ -12,4 +12,22 @@ describe('Storage', () => {
     await storage.purge();
     await expect(storage.read()).resolves.toBe(undefined);
   });
+
+  describe('when data is an object', () => {
+    it ('writes an object to persistent storage', async () => {
+      const obj = {
+        yo: 'yo yo'
+      }
+
+      await expect(storage.write(obj)).resolves.toBe(undefined);
+      await expect(storage.read()).resolves.toBe(obj);
+    })
+  })  
+
+  describe('when data is a string', () => {
+    it ('writes a string to persistent storage', async () => {
+      await expect(storage.write('yo yo yo')).resolves.toBe(undefined);
+      await expect(storage.read()).resolves.toBe('yo yo yo');
+    })
+  })
 });

--- a/src/storageWrappers/AsyncStorageWrapper.ts
+++ b/src/storageWrappers/AsyncStorageWrapper.ts
@@ -12,7 +12,7 @@ import { PersistentStorage } from '../types';
  * });
  *
  */
-export class AsyncStorageWrapper implements PersistentStorage {
+export class AsyncStorageWrapper implements PersistentStorage<string> {
   // Actual type definition: https://github.com/react-native-async-storage/async-storage/blob/master/types/index.d.ts
   private storage;
 

--- a/src/storageWrappers/IonicStorageWrapper.ts
+++ b/src/storageWrappers/IonicStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class IonicStorageWrapper implements PersistentStorage {
+export class IonicStorageWrapper implements PersistentStorage<string> {
   // Actual type definition: https://github.com/ionic-team/ionic-storage/blob/main/src/storage.ts#L102
   private storage;
 

--- a/src/storageWrappers/LocalForageWrapper.ts
+++ b/src/storageWrappers/LocalForageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class LocalForageWrapper implements PersistentStorage {
+export class LocalForageWrapper implements PersistentStorage<string | object> {
   // Actual type definition: https://github.com/localForage/localForage/blob/master/typings/localforage.d.ts#L17
   private storage;
 

--- a/src/storageWrappers/LocalStorageWrapper.ts
+++ b/src/storageWrappers/LocalStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class LocalStorageWrapper implements PersistentStorage {
+export class LocalStorageWrapper implements PersistentStorage<string> {
   // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
   private storage;
 

--- a/src/storageWrappers/MMKVStorageWrapper.ts
+++ b/src/storageWrappers/MMKVStorageWrapper.ts
@@ -11,7 +11,7 @@ import { PersistentStorage } from '../types';
  * });
  *
  */
-export class MMKVStorageWrapper implements PersistentStorage {
+export class MMKVStorageWrapper implements PersistentStorage<string> {
   // Actual type definition: https://github.com/ammarahm-ed/react-native-mmkv-storage/blob/master/index.d.ts#L27
   private storage;
 

--- a/src/storageWrappers/SessionStorageWrapper.ts
+++ b/src/storageWrappers/SessionStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class SessionStorageWrapper implements PersistentStorage {
+export class SessionStorageWrapper implements PersistentStorage<string> {
   // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
   private storage;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,15 +10,15 @@ export type TriggerFunction = (persist: () => void) => TriggerUninstallFunction;
 
 export type PersistedData<T> = T | string | null;
 
-export interface PersistentStorage {
-  getItem: (key: string) => string | null | Promise<string | null>;
-  setItem: (key: string, value: string) => void | Promise<void>;
-  removeItem: (key: string) => void | Promise<void>;
+export interface PersistentStorage<T> {
+  getItem: (key: string) => Promise<T | null> | T | null;
+  setItem: (key: string, value: T) => Promise<T> | Promise<void> | void | T;
+  removeItem: (key: string) => Promise<T> | Promise<void> | void;
 }
 
 export interface ApolloPersistOptions<TSerialized> {
   cache: ApolloCache<TSerialized>;
-  storage: PersistentStorage;
+  storage: PersistentStorage<PersistedData<TSerialized>>;
   trigger?: 'write' | 'background' | TriggerFunction | false;
   debounce?: number;
   key?: string;


### PR DESCRIPTION
Resolves #419 

This PR: https://github.com/apollographql/apollo-cache-persist/pull/388 stops the cache being written as anything other than a string.

The CachePersistor accepts an option "serialize: boolean" that can allow for data to be written to the store without being serialised to a string first. However with the .toString() coercion, when serialize is true, all that gets written to the store is [object object], rather than the object.

This change makes sense, to bring the api inline with the web storage api. However, it means all data must be stored as JSON, which, when there is a large data set, is very expensive in memory and cpu.

So this PR resolves the issue by putting the generic back in, removing the coercion, and assigning the appropriate generic to each of the storage wrappers (I think everything is string apart from localForage, but perhaps other wrappers can support non-string values)