### PR TITLE
fix(mmkv): fix MMKV wrapper compatibility with v0.5.7+

### DIFF
--- a/src/storageWrappers/AsyncStorageWrapper.ts
+++ b/src/storageWrappers/AsyncStorageWrapper.ts
@@ -12,7 +12,7 @@ import { PersistentStorage } from '../types';
  * });
  *
  */
-export class AsyncStorageWrapper implements PersistentStorage<string> {
+export class AsyncStorageWrapper implements PersistentStorage<any> {
   // Actual type definition: https://github.com/react-native-async-storage/async-storage/blob/master/types/index.d.ts
   private storage;
 
@@ -20,7 +20,7 @@ export class AsyncStorageWrapper implements PersistentStorage<string> {
     this.storage = storage;
   }
 
-  getItem(key: string): string | Promise<string | null> | null {
+  getItem(key: string): any | Promise<any> | null {
     return this.storage.getItem(key);
   }
 
@@ -28,7 +28,7 @@ export class AsyncStorageWrapper implements PersistentStorage<string> {
     return this.storage.removeItem(key);
   }
 
-  setItem(key: string, value: string): void | Promise<void> {
+  setItem(key: string, value: any): void | Promise<void> {
     return this.storage.setItem(key, value);
   }
 }

--- a/src/storageWrappers/IonicStorageWrapper.ts
+++ b/src/storageWrappers/IonicStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class IonicStorageWrapper implements PersistentStorage<string> {
+export class IonicStorageWrapper implements PersistentStorage<any> {
   // Actual type definition: https://github.com/ionic-team/ionic-storage/blob/main/src/storage.ts#L102
   private storage;
 
@@ -8,7 +8,7 @@ export class IonicStorageWrapper implements PersistentStorage<string> {
     this.storage = storage;
   }
 
-  getItem(key: string): string | Promise<string | null> | null {
+  getItem(key: string): any | Promise<any> | null {
     return this.storage.get(key);
   }
 
@@ -16,7 +16,7 @@ export class IonicStorageWrapper implements PersistentStorage<string> {
     return this.storage.remove(key);
   }
 
-  setItem(key: string, value: string): void | Promise<void> {
+  setItem(key: string, value: any): void | Promise<void> {
     return this.storage.set(key, value);
   }
 }

--- a/src/storageWrappers/LocalForageWrapper.ts
+++ b/src/storageWrappers/LocalForageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class LocalForageWrapper implements PersistentStorage<string | object> {
+export class LocalForageWrapper implements PersistentStorage<any> {
   // Actual type definition: https://github.com/localForage/localForage/blob/master/typings/localforage.d.ts#L17
   private storage;
 
@@ -8,7 +8,7 @@ export class LocalForageWrapper implements PersistentStorage<string | object> {
     this.storage = storage;
   }
 
-  getItem(key: string): string | Promise<string | null> | null {
+  getItem(key: string): any | Promise<any> | null {
     return this.storage.getItem(key);
   }
 
@@ -16,7 +16,7 @@ export class LocalForageWrapper implements PersistentStorage<string | object> {
     return this.storage.removeItem(key);
   }
 
-  setItem(key: string, value: string): void | Promise<void> {
+  setItem(key: string, value: any): void | Promise<void> {
     return new Promise((resolve, reject) => {
       this.storage
         .setItem(key, value)

--- a/src/storageWrappers/LocalStorageWrapper.ts
+++ b/src/storageWrappers/LocalStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class LocalStorageWrapper implements PersistentStorage<string> {
+export class LocalStorageWrapper implements PersistentStorage<any> {
   // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
   private storage;
 
@@ -8,7 +8,7 @@ export class LocalStorageWrapper implements PersistentStorage<string> {
     this.storage = storage;
   }
 
-  getItem(key: string): string | Promise<string | null> | null {
+  getItem(key: string): any | Promise<any> | null {
     return this.storage.getItem(key);
   }
 
@@ -16,7 +16,7 @@ export class LocalStorageWrapper implements PersistentStorage<string> {
     return this.storage.removeItem(key);
   }
 
-  setItem(key: string, value: string): void | Promise<void> {
+  setItem(key: string, value: any): void | Promise<void> {
     return this.storage.setItem(key, value);
   }
 }

--- a/src/storageWrappers/MMKVStorageWrapper.ts
+++ b/src/storageWrappers/MMKVStorageWrapper.ts
@@ -11,7 +11,7 @@ import { PersistentStorage } from '../types';
  * });
  *
  */
-export class MMKVStorageWrapper implements PersistentStorage<string> {
+export class MMKVStorageWrapper implements PersistentStorage<any> {
   // Actual type definition: https://github.com/ammarahm-ed/react-native-mmkv-storage/blob/master/index.d.ts#L27
   private storage;
 
@@ -19,7 +19,7 @@ export class MMKVStorageWrapper implements PersistentStorage<string> {
     this.storage = storage;
   }
 
-  getItem(key: string): string | Promise<string | null> | null {
+  getItem(key: string): any | Promise<any> | null {
     return this.storage.getItem(key);
   }
 
@@ -32,7 +32,7 @@ export class MMKVStorageWrapper implements PersistentStorage<string> {
     });
   }
 
-  setItem(key: string, value: string): void | Promise<void> {
+  setItem(key: string, value: any): void | Promise<void> {
     return new Promise((resolve, reject) => {
       this.storage
         .setItem(key, value)

--- a/src/storageWrappers/MMKVStorageWrapper.ts
+++ b/src/storageWrappers/MMKVStorageWrapper.ts
@@ -25,8 +25,10 @@ export class MMKVStorageWrapper implements PersistentStorage<any> {
 
   removeItem(key: string): void | Promise<void> {
     return new Promise((resolve, reject) => {
-      this.storage
-        .removeItem(key)
+      // Ensure the removeItem is thenable, even if it's not, by wrapping it to Promise.resolve
+      // The MMKV storage's removeItem is synchronous since 0.5.7, this Promise wrap allows backward compatibility
+      // https://stackoverflow.com/a/27746324/2078771
+      Promise.resolve(this.storage.removeItem(key))
         .then(() => resolve())
         .catch(() => reject());
     });

--- a/src/storageWrappers/SessionStorageWrapper.ts
+++ b/src/storageWrappers/SessionStorageWrapper.ts
@@ -1,6 +1,6 @@
 import { PersistentStorage } from '../types';
 
-export class SessionStorageWrapper implements PersistentStorage<string> {
+export class SessionStorageWrapper implements PersistentStorage<any> {
   // Actual type definition: https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L15286
   private storage;
 
@@ -8,7 +8,7 @@ export class SessionStorageWrapper implements PersistentStorage<string> {
     this.storage = storage;
   }
 
-  getItem(key: string): string | Promise<string | null> | null {
+  getItem(key: string): any | Promise<any> | null {
     return this.storage.getItem(key);
   }
 
@@ -16,7 +16,7 @@ export class SessionStorageWrapper implements PersistentStorage<string> {
     return this.storage.removeItem(key);
   }
 
-  setItem(key: string, value: string): void | Promise<void> {
+  setItem(key: string, value: any): void | Promise<void> {
     return this.storage.setItem(key, value);
   }
 }


### PR DESCRIPTION
The MMKV storage's removeItem is synchronous since 0.5.7, which caused the .then() call to fail.
This adds backwards-compatible support for both variants.

fix #431

This should be rebased and merged after #436.