### PR TITLE
Fix Advanced Doc Readme Links

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -104,8 +104,8 @@ const persistor = new CachePersistor({
 })
 ```
 
-Take a look at the [examples](./examples/react-native/src/utils/persistence/persistenceMapper.ts)
-and [it's corresponding documentation](./examples/react-native/src/utils/persistence/README.md)
+Take a look at the [examples](../examples/react-native/src/utils/persistence/persistenceMapper.ts)
+and [it's corresponding documentation](../examples/react-native/src/utils/persistence/README.md)
 
 ## Custom Triggers
 


### PR DESCRIPTION
### This PR fixes two broken example links
https://github.com/apollographql/apollo-cache-persist/commit/f9aa7356fea4ff5014746a24df296fb854cc8e00 moved out some of the docs into the `docs/advanced-usage.md` directory. I'm not sure why, but doing so seems to have broken the linking of the examples (perhaps they were already broken).