### PR TITLE
Added optional `getSize` func to Storage.

### DIFF
--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -28,6 +28,10 @@ export default class Storage<T> {
   }
 
   async getSize(): Promise<number | null> {
+    if (this.storage.getSize) {
+      return this.storage.getSize(this.key);
+    }
+
     const data = await this.storage.getItem(this.key);
 
     if (data == null) {

--- a/src/__mocks__/MockStorage.ts
+++ b/src/__mocks__/MockStorage.ts
@@ -1,29 +1,37 @@
 import { PersistentStorage } from '../types';
 
-export default class MockStorage implements PersistentStorage {
-  storage: Map<string, string>;
+export default class MockStorage implements PersistentStorage<any> {
+  storage: Map<string, any>;
 
   constructor() {
     this.storage = new Map();
   }
 
-  setItem(key: string, data: string): Promise<any> {
+  setItem(key: string, data: any): Promise<void> {
     return new Promise(resolve => {
       this.storage.set(key, data);
       resolve();
     });
   }
 
-  removeItem(key: string): Promise<any> {
+  removeItem(key: string): Promise<void> {
     return new Promise((resolve, reject) => {
       this.storage.delete(key);
       resolve();
     });
   }
 
-  getItem(key: string): Promise<string> {
+  getItem(key: string): Promise<any> {
     return new Promise((resolve, reject) => {
       resolve(this.storage.get(key));
+    });
+  }
+
+  getSize(key: string): Promise<number> {
+    return new Promise(resolve => {
+      if (this.storage.size === 0) return resolve(0);
+      const data = this.storage.get(key);
+      resolve((typeof data === 'string' ? data : JSON.stringify(data)).length);
     });
   }
 }

--- a/src/__tests__/Storage.ts
+++ b/src/__tests__/Storage.ts
@@ -4,7 +4,7 @@ import Storage from '../Storage';
 describe('Storage', () => {
   const storage = new Storage({
     storage: new MockStorage(),
-  });
+  } as any);
 
   it('writes, reads, & deletes data from persistent storage', async () => {
     await expect(storage.write('yo yo yo')).resolves.toBe(undefined);
@@ -28,6 +28,26 @@ describe('Storage', () => {
     it ('writes a string to persistent storage', async () => {
       await expect(storage.write('yo yo yo')).resolves.toBe(undefined);
       await expect(storage.read()).resolves.toBe('yo yo yo');
+    })
+  })
+
+  describe('when it has a getSize function', () => {
+    it('calculates its own size', async () => {
+      storage.purge();
+      await expect(storage.getSize()).resolves.toBe(0);
+      await expect(storage.write('yo yo yo')).resolves.toBe(undefined);
+      await expect(storage.getSize()).resolves.toBeGreaterThan(0);
+    })
+  })
+
+  describe('when it does not have a getSize function', () => {
+    it('calculates based on string size if applicable', async () => {
+      const originalGetSize = storage.storage.getSize;
+      const content = 'yo yo yo yo';
+      storage.storage.getSize = undefined;
+      await expect(storage.write(content)).resolves.toBe(undefined);
+      await expect(storage.getSize()).resolves.toBe(content.length);
+      storage.storage.getSize = originalGetSize;
     })
   })
 });

--- a/src/storageWrappers/LocalStorageWrapper.ts
+++ b/src/storageWrappers/LocalStorageWrapper.ts
@@ -23,6 +23,10 @@ export class LocalStorageWrapper implements PersistentStorage<string | null> {
       return this.removeItem(key);
     }
   }
+
+  getSize(): number {
+    return new Blob(Object.values(this.storage)).size;
+  }
 }
 
 interface LocalStorageInterface {
@@ -30,4 +34,10 @@ interface LocalStorageInterface {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
   removeItem(key: string): void;
+}
+
+declare class Blob {
+  // Actual type defintion: https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L2418
+  constructor(data: any);
+  readonly size: number;
 }

--- a/src/storageWrappers/SessionStorageWrapper.ts
+++ b/src/storageWrappers/SessionStorageWrapper.ts
@@ -23,6 +23,10 @@ export class SessionStorageWrapper implements PersistentStorage<string | null> {
       return this.removeItem(key);
     }
   }
+
+  getSize(): number {
+    return new Blob(Object.values(this.storage)).size;
+  }
 }
 
 interface SessionStorageInterface {
@@ -30,4 +34,10 @@ interface SessionStorageInterface {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
   removeItem(key: string): void;
+}
+
+declare class Blob {
+  // Actual type defintion: https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L2418
+  constructor(data: any);
+  readonly size: number;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export interface PersistentStorage<T> {
   getItem: (key: string) => Promise<T | null> | T | null;
   setItem: (key: string, value: T) => Promise<T> | Promise<void> | void | T;
   removeItem: (key: string) => Promise<T> | Promise<void> | void;
+  getSize?(key: string): Promise<number> | number | null;
 }
 
 type StorageType<T, TSerialize extends boolean> = TSerialize extends true


### PR DESCRIPTION
- Allows for storage instances to calculate their own size.
- Fixes Fixes `CachePersistor`'s `getSize` function when serialize is `false`.
- #427 