### PR TITLE
fix(types): remove unused keys

### DIFF
--- a/src/storageWrappers/MMKVWrapper.ts
+++ b/src/storageWrappers/MMKVWrapper.ts
@@ -37,10 +37,6 @@ export class MMKVWrapper implements PersistentStorage<string | null> {
 
 interface MMKVInterface {
     set: (key: string, value: boolean | string | number) => void;
-    getBoolean: (key: string) => boolean;
     getString: (key: string) => string | undefined;
-    getNumber: (key: string) => number;
     delete: (key: string) => void;
-    getAllKeys: () => string[];
-    clearAll: () => void;
 }


### PR DESCRIPTION
Do not limit unused keys, their types don't match anymore and there is no need to have them.