### PR TITLE
Make storage to protected in wrappers for inheritance

### DIFF
--- a/src/storageWrappers/AsyncStorageWrapper.ts
+++ b/src/storageWrappers/AsyncStorageWrapper.ts
@@ -13,7 +13,7 @@ import { PersistentStorage } from '../types';
  *
  */
 export class AsyncStorageWrapper implements PersistentStorage<string | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: AsyncStorageInterface) {
     this.storage = storage;

--- a/src/storageWrappers/IonicStorageWrapper.ts
+++ b/src/storageWrappers/IonicStorageWrapper.ts
@@ -1,7 +1,7 @@
 import { PersistentStorage } from '../types';
 
 export class IonicStorageWrapper implements PersistentStorage<string | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: IonicStorageInterface) {
     this.storage = storage;

--- a/src/storageWrappers/LocalForageWrapper.ts
+++ b/src/storageWrappers/LocalForageWrapper.ts
@@ -2,7 +2,7 @@ import { PersistentStorage } from '../types';
 
 export class LocalForageWrapper
   implements PersistentStorage<string | object | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: LocalForageInterface) {
     this.storage = storage;

--- a/src/storageWrappers/LocalStorageWrapper.ts
+++ b/src/storageWrappers/LocalStorageWrapper.ts
@@ -1,7 +1,7 @@
 import { PersistentStorage } from '../types';
 
 export class LocalStorageWrapper implements PersistentStorage<string | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: LocalStorageInterface) {
     this.storage = storage;

--- a/src/storageWrappers/MMKVStorageWrapper.ts
+++ b/src/storageWrappers/MMKVStorageWrapper.ts
@@ -12,7 +12,7 @@ import { PersistentStorage } from '../types';
  *
  */
 export class MMKVStorageWrapper implements PersistentStorage<string | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: MMKVStorageInterface) {
     this.storage = storage;

--- a/src/storageWrappers/MMKVWrapper.ts
+++ b/src/storageWrappers/MMKVWrapper.ts
@@ -13,7 +13,7 @@ import { PersistentStorage } from '../types';
  *
  */
 export class MMKVWrapper implements PersistentStorage<string | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: MMKVInterface) {
     this.storage = storage;

--- a/src/storageWrappers/SessionStorageWrapper.ts
+++ b/src/storageWrappers/SessionStorageWrapper.ts
@@ -1,7 +1,7 @@
 import { PersistentStorage } from '../types';
 
 export class SessionStorageWrapper implements PersistentStorage<string | null> {
-  private storage;
+  protected storage;
 
   constructor(storage: SessionStorageInterface) {
     this.storage = storage;


### PR DESCRIPTION
Closes #464 

Makes the `storage` instance variable in each of the wrappers `protected` instead of `private` to make it possible to inherit from the existing wrappers in new custom wrappers.