### PR TITLE
Update AppState usage to avoid deprecated API

### DIFF
--- a/src/onAppBackground.native.ts
+++ b/src/onAppBackground.native.ts
@@ -12,6 +12,6 @@ export default () => (persist: () => void) => {
     }
   };
 
-  AppState.addEventListener('change', listener);
-  return () => AppState.removeEventListener('change', listener);
+  const subscription = AppState.addEventListener('change', listener);
+  return () => subscription.remove();
 };


### PR DESCRIPTION
removeEventListener was deprecated in RN 0.65

https://reactnative.dev/docs/0.65/appstate#addeventlistener