### PR TITLE
Add `Capacitor Preferences` storage provider

### DIFF
--- a/docs/storage-providers.md
+++ b/docs/storage-providers.md
@@ -9,15 +9,16 @@
 
 `apollo3-cache-persist` provides wrappers for the following storage providers, with no additional dependencies:
 
-| Storage provider                                                                | Platform       | Wrapper class           |
-| ------------------------------------------------------------------------------- | -------------- | ----------------------- |
-| [`AsyncStorage`](https://github.com/react-native-async-storage/async-storage)\* | React Native   | `AsyncStorageWrapper`   |
-| `window.localStorage`                                                           | web            | `LocalStorageWrapper`   |
-| `window.sessionStorage`                                                         | web            | `SessionStorageWrapper` |
-| [`localForage`](https://github.com/localForage/localForage)                     | web            | `LocalForageWrapper`    |
-| [`Ionic storage`](https://ionicframework.com/docs/building/storage)             | web and mobile | `IonicStorageWrapper`   |
-| [`MMKV Storage`](https://github.com/ammarahm-ed/react-native-mmkv-storage)      | React Native   | `MMKVStorageWrapper`    |
-| [`MMKV`](https://github.com/mrousavy/react-native-mmkv)                         | React Native   | `MMKVWrapper`           |
+| Storage provider                                                                | Platform       | Wrapper class                 |
+|---------------------------------------------------------------------------------|----------------|-------------------------------|
+| [`AsyncStorage`](https://github.com/react-native-async-storage/async-storage)\* | React Native   | `AsyncStorageWrapper`         |
+| `window.localStorage`                                                           | web            | `LocalStorageWrapper`         |
+| `window.sessionStorage`                                                         | web            | `SessionStorageWrapper`       |
+| [`localForage`](https://github.com/localForage/localForage)                     | web            | `LocalForageWrapper`          |
+| [`Ionic storage`](https://ionicframework.com/docs/building/storage)             | web and mobile | `IonicStorageWrapper`         |
+| [`MMKV Storage`](https://github.com/ammarahm-ed/react-native-mmkv-storage)      | React Native   | `MMKVStorageWrapper`          |
+| [`MMKV`](https://github.com/mrousavy/react-native-mmkv)                         | React Native   | `MMKVWrapper`                 |
+| [`Capacitor Preferences`](https://capacitorjs.com/docs/apis/preferences)        | Capacitor      | `CapacitorPreferencesWrapper` |
 
 
 ## Redux Persist Providers

--- a/src/storageWrappers/CapacitorPreferencesWrapper.ts
+++ b/src/storageWrappers/CapacitorPreferencesWrapper.ts
@@ -8,18 +8,19 @@ export class CapacitorPreferencesWrapper implements PersistentStorage<string | n
   }
 
   getItem(key: string): Promise<string | null> {
-    return this.storage.get({key: key}).then(r => r.value)
+    return this.storage.get({key: key}).then(r => r.value);
   }
 
   removeItem(key: string): Promise<void> {
-    return this.storage.remove({key: key})
+    return this.storage.remove({key: key});
   }
 
   setItem(key: string, value: string | null): Promise<void> {
     if (value) {
-      return this.storage.set({key: key, value: value})
+      // Capacitor Preferences does not support nullable values
+      return this.storage.set({key: key, value: value});
     } else {
-      return Promise.reject("Value was null")
+      return this.removeItem(key);
     }
   }
 }

--- a/src/storageWrappers/CapacitorPreferencesWrapper.ts
+++ b/src/storageWrappers/CapacitorPreferencesWrapper.ts
@@ -1,0 +1,34 @@
+import {PersistentStorage} from "../types";
+
+export class CapacitorPreferencesWrapper implements PersistentStorage<string | null> {
+  private storage;
+
+  constructor(storage: CapacitorPreferencesInterface) {
+    this.storage = storage;
+  }
+
+  getItem(key: string): Promise<string | null> {
+    return this.storage.get({key: key}).then(r => r.value)
+  }
+
+  removeItem(key: string): Promise<void> {
+    return this.storage.remove({key: key})
+  }
+
+  setItem(key: string, value: string | null): Promise<void> {
+    if (value) {
+      return this.storage.set({key: key, value: value})
+    } else {
+      return Promise.reject("Value was null")
+    }
+  }
+}
+
+interface CapacitorPreferencesInterface {
+  // Actual type definition: https://capacitorjs.com/docs/apis/preferences#api
+  get(options: { key: string }): Promise<{ value: string | null }>;
+
+  set(options: { key: string, value: string }): Promise<void>;
+
+  remove(options: { key: string }): Promise<void>;
+}

--- a/src/storageWrappers/index.ts
+++ b/src/storageWrappers/index.ts
@@ -5,3 +5,4 @@ export * from './LocalStorageWrapper';
 export * from './MMKVStorageWrapper';
 export * from './MMKVWrapper';
 export * from './SessionStorageWrapper';
+export * from './CapacitorPreferencesWrapper';


### PR DESCRIPTION
[Capacitor](https://capacitorjs.com/), a cross-platform native runtime for web apps, offers an API to persist data onto the device it's running on.
I added a `PersistentStorage` implementation for this API in this pull request.

Let me know if you have any questions! 