### PR TITLE
feat: allow persistence of optimistic data

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -4,16 +4,18 @@ import { ApolloPersistOptions, PersistedData } from './types';
 export default class Cache<T> {
   cache: ApolloCache<T>;
   serialize: boolean;
+  includeOptimistic: boolean;
 
-  constructor(options: Pick<ApolloPersistOptions<T>, 'cache' | 'serialize'>) {
-    const { cache, serialize = true } = options;
+  constructor(options: Pick<ApolloPersistOptions<T>, 'cache' | 'serialize' | 'includeOptimistic'>) {
+    const { cache, serialize = true, includeOptimistic = false } = options;
 
     this.cache = cache;
     this.serialize = serialize;
+    this.includeOptimistic = includeOptimistic;
   }
 
   extract(): PersistedData<T> {
-    let data: PersistedData<T> = this.cache.extract() as T;
+    let data: PersistedData<T> = this.cache.extract(this.includeOptimistic) as T;
 
     if (this.serialize) {
       data = JSON.stringify(data) as string;

--- a/src/__mocks__/MockCache.ts
+++ b/src/__mocks__/MockCache.ts
@@ -6,11 +6,13 @@ export default class MockCache<T, U extends boolean = true>
 {
   cache: null;
   serialize: boolean;
+  includeOptimistic: boolean;
   data: PersistedData<T>;
 
-  constructor(options: Pick<ApolloPersistOptions<T, U>, 'serialize'>) {
-    const { serialize = true } = options;
+  constructor(options: Pick<ApolloPersistOptions<T, U>, 'serialize' | 'includeOptimistic'>) {
+    const { serialize = true, includeOptimistic = false } = options;
     this.serialize = serialize;
+    this.includeOptimistic = includeOptimistic;
   }
 
   extract(): PersistedData<T> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,4 +35,5 @@ export interface ApolloPersistOptions<
   maxSize?: number | false;
   persistenceMapper?: PersistenceMapperFunction;
   debug?: boolean;
+  includeOptimistic?: boolean;
 }


### PR DESCRIPTION
This change allows to pass a `includeOptimistic` boolean to the `CachePersistor` options. This boolean is further passed down to Apollo's `cache.extract()` function, [which accepts a boolean](https://www.apollographql.com/docs/react/api/cache/InMemoryCache/#extract), to allow the extraction (and thus, persistence) of optimistic data.

This PR aims to solve issues related to implementing offline use of applications relying on Apollo Client like  https://github.com/apollographql/apollo-cache-persist/issues/410