### PR TITLE
feat(types): turn `LocalForageWrapper` into a generic class

### DIFF
--- a/src/storageWrappers/LocalForageWrapper.ts
+++ b/src/storageWrappers/LocalForageWrapper.ts
@@ -1,14 +1,15 @@
 import { PersistentStorage } from '../types';
 
-export class LocalForageWrapper
-  implements PersistentStorage<string | object | null> {
+export class LocalForageWrapper<T = string | object | null>
+  implements PersistentStorage<T>
+{
   protected storage;
 
-  constructor(storage: LocalForageInterface) {
+  constructor(storage: LocalForageInterface<T>) {
     this.storage = storage;
   }
 
-  getItem(key: string): Promise<string | null> {
+  getItem(key: string): Promise<T | null> {
     return this.storage.getItem(key);
   }
 
@@ -16,7 +17,7 @@ export class LocalForageWrapper
     return this.storage.removeItem(key);
   }
 
-  setItem(key: string, value: string | object | null): Promise<void> {
+  setItem(key: string, value: T | null): Promise<void> {
     return new Promise((resolve, reject) => {
       this.storage
         .setItem(key, value)
@@ -26,12 +27,9 @@ export class LocalForageWrapper
   }
 }
 
-interface LocalForageInterface {
+export interface LocalForageInterface<T = string | object | null> {
   // Actual type definition: https://github.com/localForage/localForage/blob/master/typings/localforage.d.ts#L17
-  getItem(key: string): Promise<string | null>;
-  setItem(
-    key: string,
-    value: string | object | null,
-  ): Promise<string | object | null>;
+  getItem(key: string): Promise<T | null>;
+  setItem(key: string, value: T | null): Promise<T | null>;
   removeItem(key: string): Promise<void>;
 }


### PR DESCRIPTION
`LocalForageWrapper` is currently typed as `string | object | null,` but it solely depends on whether we serialize or not.

Also, [`localForage`](https://github.com/localForage/localForage) (and IndexedDB) supports storing more than `string` or `object`, it supports the following JS objects:

- Array
- ArrayBuffer
- Blob
- Float32Array
- Float64Array
- Int8Array
- Int16Array
- Int32Array
- Number
- Object
- Uint8Array
- Uint8ClampedArray
- Uint16Array
- Uint32Array
- String

I didn't want to introduce a breaking change by changing the type, so instead, I turned `LocalForageWrapper` into a generic class expecting a type for LocalForage and defaulting to `string | object | null` (current value).

It means that if you're storing binary data in IndexedDB, you can provide the type as such: `LocalForageWrapper<Uint8Array>`.