### PR TITLE
chore(types): document `ApolloPersistOptions` parameters

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,15 +24,50 @@ type StorageType<T, TSerialize extends boolean> = TSerialize extends true
 
 export interface ApolloPersistOptions<
   TSerialized,
-  TSerialize extends boolean = true
+  TSerialize extends boolean = true,
 > {
+  /**
+   * Reference to your Apollo cache.
+   */
   cache: ApolloCache<TSerialized>;
+  /**
+   * Reference to your storage provider wrapped in a storage wrapper implementing `PersistentStorage` interface.
+   */
   storage: StorageType<PersistedData<TSerialized>, TSerialize>;
+  /**
+   * When to persist the cache.
+   *
+   * `write`: Persist upon every write to the cache. Default.
+   *
+   * `background`: Persist when your app moves to the background. **React Native only**.
+   *
+   * For a custom trigger, provide a function. See below for more information.
+   *
+   * To disable automatic persistence and manage persistence manually, provide `false`.
+   */
   trigger?: 'write' | 'background' | TriggerFunction | false;
+  /**
+   * Debounce interval between persists (in ms).
+   * Defaults to `0` for `background` and `1000` for `write` and custom triggers.
+   */
   debounce?: number;
+  /**
+   * Key to use with the storage provider. Defaults to `apollo-cache-persist`.
+   */
   key?: string;
+  /**
+   * Whether to serialize to JSON before/after persisting. Defaults to `true`.
+   */
   serialize?: TSerialize;
+  /**
+   * Maximum size of cache to persist (in bytes).
+   * Defaults to `1048576` (1 MB). For unlimited cache size, provide `false`.
+   * If exceeded, persistence will pause and app will start up cold on next launch.
+   */
   maxSize?: number | false;
   persistenceMapper?: PersistenceMapperFunction;
+  /**
+   * Enable console logging.
+   */
   debug?: boolean;
 }


### PR DESCRIPTION
Most options of `persistCache` were already documented in [`advanced-usage.md`](https://github.com/apollographql/apollo-cache-persist/blob/719048da47f9a3885598c3093d02bd1f106bc2de/docs/advanced-usage.md#L54), but they were missing in the TypeScript file, meaning that it doesn't show up in the IDE.

I would prefer to have this show up in the IDE directly so I don't have to search for it in markdown files, so here they are.